### PR TITLE
feat: support ClickHouse values can be overridden by Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ ClickHouse runs on ClickHouse Cloud or any Linux, FreeBSD, or macOS system with 
 
 1. Build the exporter, using `mvn package`.
 2. Copy the resulting `zeebe-clickhouse-exporter-1.0-SNAPSHOT.jar` file to the `exporters` directory of your Zeebe broker.
-3. Edit the `application.xml` file, and add an entry for the exporter:
+3. Edit the `application.xml` file, and add an entry for the exporter, you can change
+
+   * the ClickHouse jdbc url `chUrl`
+   * the ClickHouse user `chUser`
+   * the ClickHouse password `chPassword`
 
 ```
     exporters:
@@ -45,8 +49,14 @@ ClickHouse runs on ClickHouse Cloud or any Linux, FreeBSD, or macOS system with 
         args:
           chUrl: jdbc:ch://127.0.0.1:8123/default
           chUser: default
-          chPassword: clickhouse123
+          chPassword:
 ```
+The values can be overridden by environment variables.
+
+  * set `chUrl` with `ZEEBE_CLICKHOUSE_URL` (e.g. `export ZEEBE_CLICKHOUSE_URL=jdbc:ch://127.0.0.1:8123/default`)
+  * set `chUser` with `ZEEBE_CLICKHOUSE_USER` (e.g. `export ZEEBE_CLICKHOUSE_USER=default`)
+  * set `chPassword` with `ZEEBE_CLICKHOUSE_PASSWORD` (e.g. `export ZEEBE_CLICKHOUSE_PASSWORD=""`)
+
 
 ## ClickHouse Zeebe Tables
 

--- a/src/main/java/io/zeebe/clickhouse/exporter/ClickHouseExporterClient.java
+++ b/src/main/java/io/zeebe/clickhouse/exporter/ClickHouseExporterClient.java
@@ -23,93 +23,93 @@ public class ClickHouseExporterClient {
     try {
       // 初始化配置表
       ClickHouseConfig.CreateClickHouseConfigTable(
-          configuration.chUrl,
-          configuration.chUser,
-          configuration.chPassword,
+          configuration.getChUrl(),
+          configuration.getChUser(),
+          configuration.getChPassword(),
           clickHouseConfigTable);
       // 检查是否有初始化配置信息
       final long i =
           ClickHouseConfig.queryClickHouseConfig(
-              configuration.chUrl,
-              configuration.chUser,
-              configuration.chPassword,
+              configuration.getChUrl(),
+              configuration.getChUser(),
+              configuration.getChPassword(),
               clickHouseConfigTable);
 
       if (i <= 0L) {
         // 执行初始化
         ClickHouseConfig.InitClickHouseConfigTable(
-            configuration.chUrl,
-            configuration.chUser,
-            configuration.chPassword,
+            configuration.getChUrl(),
+            configuration.getChUser(),
+            configuration.getChPassword(),
             clickHouseConfigTable);
       } else {
         cfgPosition = i;
       }
       // 创建流程定义信息表
       ClickHouseConfig.CreateProcessTable(
-          configuration.chUrl,
-          configuration.chUser,
-          configuration.chPassword,
+          configuration.getChUrl(),
+          configuration.getChUser(),
+          configuration.getChPassword(),
           ValueType.PROCESS.name());
       // 创建流程实例表
       ClickHouseConfig.CreateProcessInstanceTable(
-          configuration.chUrl,
-          configuration.chUser,
-          configuration.chPassword,
+          configuration.getChUrl(),
+          configuration.getChUser(),
+          configuration.getChPassword(),
           ValueType.PROCESS_INSTANCE.name());
       // 创建任务实例表
       ClickHouseConfig.CreateElementInstanceTable(
-          configuration.chUrl,
-          configuration.chUser,
-          configuration.chPassword,
+          configuration.getChUrl(),
+          configuration.getChUser(),
+          configuration.getChPassword(),
           elementInstanceTable);
       // 创建调度表
       ClickHouseConfig.CreateJobTable(
-          configuration.chUrl,
-          configuration.chUser,
-          configuration.chPassword,
+          configuration.getChUrl(),
+          configuration.getChUser(),
+          configuration.getChPassword(),
           ValueType.JOB.name());
       // 创建流程变量表
       ClickHouseConfig.CreateVariableTable(
-          configuration.chUrl,
-          configuration.chUser,
-          configuration.chPassword,
+          configuration.getChUrl(),
+          configuration.getChUser(),
+          configuration.getChPassword(),
           ValueType.VARIABLE.name());
       // 创建事件表
       ClickHouseConfig.CreateIncidentTable(
-          configuration.chUrl,
-          configuration.chUser,
-          configuration.chPassword,
+          configuration.getChUrl(),
+          configuration.getChUser(),
+          configuration.getChPassword(),
           ValueType.INCIDENT.name());
       // 创建定时器表
       ClickHouseConfig.CreateTimerTable(
-          configuration.chUrl,
-          configuration.chUser,
-          configuration.chPassword,
+          configuration.getChUrl(),
+          configuration.getChUser(),
+          configuration.getChPassword(),
           ValueType.TIMER.name());
       // 创建异常表
       ClickHouseConfig.CreateErrorTable(
-          configuration.chUrl,
-          configuration.chUser,
-          configuration.chPassword,
+          configuration.getChUrl(),
+          configuration.getChUser(),
+          configuration.getChPassword(),
           ValueType.ERROR.name());
       // 创建消息表
       ClickHouseConfig.CreateMessageTable(
-          configuration.chUrl,
-          configuration.chUser,
-          configuration.chPassword,
+          configuration.getChUrl(),
+          configuration.getChUser(),
+          configuration.getChPassword(),
           ValueType.MESSAGE.name());
       // 创建消息订阅表
       ClickHouseConfig.CreateMessageSubscriptionTable(
-          configuration.chUrl,
-          configuration.chUser,
-          configuration.chPassword,
+          configuration.getChUrl(),
+          configuration.getChUser(),
+          configuration.getChPassword(),
           ValueType.MESSAGE_SUBSCRIPTION.name());
       // 创建信号订阅表
       ClickHouseConfig.CreateSignalSubscriptionTable(
-          configuration.chUrl,
-          configuration.chUser,
-          configuration.chPassword,
+          configuration.getChUrl(),
+          configuration.getChUser(),
+          configuration.getChPassword(),
           ValueType.SIGNAL_SUBSCRIPTION.name());
 
     } catch (final SQLException e) {
@@ -128,9 +128,9 @@ public class ClickHouseExporterClient {
         try {
 
           ProcessImporter.batchProcessInsert(
-              configuration.chUrl,
-              configuration.chUser,
-              configuration.chPassword,
+              configuration.getChUrl(),
+              configuration.getChUser(),
+              configuration.getChPassword(),
               ValueType.PROCESS.name(),
               record);
           // 更新记录位置
@@ -145,17 +145,17 @@ public class ClickHouseExporterClient {
 
           // 流程实例信息
           ProcessInstanceImporter.batchProcessInstanceInsertOrUpdate(
-              configuration.chUrl,
-              configuration.chUser,
-              configuration.chPassword,
+              configuration.getChUrl(),
+              configuration.getChUser(),
+              configuration.getChPassword(),
               ValueType.PROCESS_INSTANCE.name(),
               record);
 
           // 任务实例信息
           ProcessInstanceImporter.batchElementInstanceInsert(
-              configuration.chUrl,
-              configuration.chUser,
-              configuration.chPassword,
+              configuration.getChUrl(),
+              configuration.getChUser(),
+              configuration.getChPassword(),
               elementInstanceTable,
               record);
           // 更新记录位置
@@ -170,9 +170,9 @@ public class ClickHouseExporterClient {
         try {
 
           JobImporter.batchJobInsertOrUpdate(
-              configuration.chUrl,
-              configuration.chUser,
-              configuration.chPassword,
+              configuration.getChUrl(),
+              configuration.getChUser(),
+              configuration.getChPassword(),
               ValueType.JOB.name(),
               record);
           // 更新记录位置
@@ -186,9 +186,9 @@ public class ClickHouseExporterClient {
         try {
 
           VariableImporter.batchVariableInsert(
-              configuration.chUrl,
-              configuration.chUser,
-              configuration.chPassword,
+              configuration.getChUrl(),
+              configuration.getChUser(),
+              configuration.getChPassword(),
               ValueType.VARIABLE.name(),
               record);
           // 更新记录位置
@@ -202,9 +202,9 @@ public class ClickHouseExporterClient {
         try {
 
           IncidentImporter.batchIncidentInsertOrUpdate(
-              configuration.chUrl,
-              configuration.chUser,
-              configuration.chPassword,
+              configuration.getChUrl(),
+              configuration.getChUser(),
+              configuration.getChPassword(),
               ValueType.INCIDENT.name(),
               record);
           // 更新记录位置
@@ -218,9 +218,9 @@ public class ClickHouseExporterClient {
         try {
 
           TimerImporter.batchTimerInsert(
-              configuration.chUrl,
-              configuration.chUser,
-              configuration.chPassword,
+              configuration.getChUrl(),
+              configuration.getChUser(),
+              configuration.getChPassword(),
               ValueType.TIMER.name(),
               record);
           // 更新记录位置
@@ -234,9 +234,9 @@ public class ClickHouseExporterClient {
         try {
 
           ErrorImporter.batchErrorInsert(
-              configuration.chUrl,
-              configuration.chUser,
-              configuration.chPassword,
+              configuration.getChUrl(),
+              configuration.getChUser(),
+              configuration.getChPassword(),
               ValueType.ERROR.name(),
               record);
           // 更新记录位置
@@ -250,9 +250,9 @@ public class ClickHouseExporterClient {
         try {
 
           MessageImporter.batchMessageInsert(
-              configuration.chUrl,
-              configuration.chUser,
-              configuration.chPassword,
+              configuration.getChUrl(),
+              configuration.getChUser(),
+              configuration.getChPassword(),
               ValueType.MESSAGE.name(),
               record);
           // 更新记录位置
@@ -266,9 +266,9 @@ public class ClickHouseExporterClient {
         try {
 
           MessageSubscriptionImporter.batchMessageSubscriptionInsert(
-              configuration.chUrl,
-              configuration.chUser,
-              configuration.chPassword,
+              configuration.getChUrl(),
+              configuration.getChUser(),
+              configuration.getChPassword(),
               ValueType.MESSAGE_SUBSCRIPTION.name(),
               record);
           // 更新记录位置
@@ -282,9 +282,9 @@ public class ClickHouseExporterClient {
         try {
 
           MessageSubscriptionImporter.batchMessageStartEventSubscriptionInsert(
-              configuration.chUrl,
-              configuration.chUser,
-              configuration.chPassword,
+              configuration.getChUrl(),
+              configuration.getChUser(),
+              configuration.getChPassword(),
               ValueType.MESSAGE_SUBSCRIPTION.name(),
               record);
           // 更新记录位置
@@ -298,9 +298,9 @@ public class ClickHouseExporterClient {
         try {
 
           SignalSubscriptionImporter.batchSignalSubscriptionInsert(
-              configuration.chUrl,
-              configuration.chUser,
-              configuration.chPassword,
+              configuration.getChUrl(),
+              configuration.getChUser(),
+              configuration.getChPassword(),
               ValueType.SIGNAL_SUBSCRIPTION.name(),
               record);
           // 更新记录位置
@@ -316,9 +316,9 @@ public class ClickHouseExporterClient {
   public void update(final long lastPosition) {
     try {
       ClickHouseConfig.updateClickHouseConfigTable(
-          configuration.chUrl,
-          configuration.chUser,
-          configuration.chPassword,
+          configuration.getChUrl(),
+          configuration.getChUser(),
+          configuration.getChPassword(),
           clickHouseConfigTable,
           lastPosition);
     } catch (final SQLException e) {

--- a/src/main/java/io/zeebe/clickhouse/exporter/ExporterConfiguration.java
+++ b/src/main/java/io/zeebe/clickhouse/exporter/ExporterConfiguration.java
@@ -1,9 +1,28 @@
 package io.zeebe.clickhouse.exporter;
 
+import java.util.Optional;
+
 public class ExporterConfiguration {
-  public String chUrl = "jdbc:ch://127.0.0.1:8123/default";
-  public String chUser = "default";
-  public String chPassword = "clickhouse123";
+  private static final String ENV_PREFIX = "ZEEBE_CLICKHOUSE_";
+  private String chUrl = "jdbc:ch://127.0.0.1:8123/default";
+  private String chUser = "default";
+  private String chPassword = "";
+
+  public String getChUrl() {
+    return getEnv("URL").orElse(chUrl);
+  }
+
+  public String getChUser() {
+    return getEnv("USER").orElse(chUser);
+  }
+
+  public String getChPassword() {
+    return getEnv("PASSWORD").orElse(chPassword);
+  }
+
+  private Optional<String> getEnv(String name) {
+    return Optional.ofNullable(System.getenv(ENV_PREFIX + name));
+  }
 
   @Override
   public String toString() {


### PR DESCRIPTION

Support ClickHouse configuration values can be overridden by environment variables.

1. set `chUrl` with `ZEEBE_CLICKHOUSE_URL` (e.g. `export ZEEBE_CLICKHOUSE_URL=jdbc:ch://127.0.0.1:8123/default`)
2. set `chUser` with `ZEEBE_CLICKHOUSE_USER` (e.g. `export ZEEBE_CLICKHOUSE_USER=default`)
3. set `chPassword` with `ZEEBE_CLICKHOUSE_PASSWORD` (e.g. `export ZEEBE_CLICKHOUSE_PASSWORD=""`)